### PR TITLE
chore: Update LICENSE copyright assignment + year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Chaos Initiative
+Copyright (c) 2023 P2CE Team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Chaos Initiative is no longer a thing, update copyright assignment to P2CE Team. 